### PR TITLE
Add bash completion for the gpdscreen command

### DIFF
--- a/gpdscreen-completion.bash
+++ b/gpdscreen-completion.bash
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+complete -W "portrait invertedportrait highdpi normaldpi touchreset" gpdscreen

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,10 @@ chmod 0644 /etc/X11/xinit/xinitrc.d/90-gpdscreen
 cp daemons/gpdscreen.sh /usr/local/sbin/gpdscreen
 chmod +x /usr/local/sbin/gpdscreen
 
+# Add bash completion
+cp gpdscreen-completion.bash /etc/bash_completion.d/gpdscreen
+chmod +x /etc/bash_completion.d/gpdscreen
+
 # Add script relaunch on wake
 cp daemons/gpdscreen /lib/systemd/system-sleep/gpdscreen
 chmod +x /lib/systemd/system-sleep/gpdscreen


### PR DESCRIPTION
I often find it's hard to use the gui to fix the rotation; it's easier to alt-tab to a terminal and run gpdscreen

But I keep forgetting if it's highdpi or hidpi...

This lets me "gpdscreen <tab>" and be reminded of the choices, or "gpdscreen hi<tab>" and have it completed for me.